### PR TITLE
Move action buttons to footer on stage info modal on map

### DIFF
--- a/apps/distortion/src/app/interfaces/map-layer.ts
+++ b/apps/distortion/src/app/interfaces/map-layer.ts
@@ -16,6 +16,7 @@ export enum MapLayer {
   StageHighlight = 'stage-highlight',
   Asset = 'asset_geojson',
   AssetIcon = 'asset_geojson-icon',
+  AssetHighlight = 'asset-highlight',
 }
 
 export enum StageLayer {

--- a/apps/distortion/src/app/pages/map/feature-info-modal/asset/asset.component.html
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/asset/asset.component.html
@@ -6,7 +6,11 @@
 
     <ion-buttons slot="end">
       <ng-container *ngIf="location$ | async as location">
-        <ion-button (click)="onOpenGoogleMapsDirections(location)">
+        <ion-button
+          color="primary"
+          fill="outline"
+          (click)="onOpenGoogleMapsDirections(location)"
+        >
           Directions
         </ion-button>
       </ng-container>

--- a/apps/distortion/src/app/pages/map/feature-info-modal/feature-info-modal.component.ts
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/feature-info-modal.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  OnInit,
   inject,
 } from '@angular/core';
 import {
@@ -32,21 +31,18 @@ import { IonContent } from '@ionic/angular/standalone';
     IonContent,
   ],
 })
-export class FeatureInfoModalComponent implements OnInit {
+export class FeatureInfoModalComponent {
   private mapStateService = inject(MapStateService);
   private mapService = inject(MapService);
 
-  selectedFeature$: Observable<MapClickedFeature<GeojsonProperties>>;
   mapLayer = MapLayer;
 
-  ngOnInit() {
-    this.selectedFeature$ = this.mapStateService.selectedMapFeature$.pipe(
-      tap((feature) =>
-        this.mapService.flyTo(
-          feature.geometry.coordinates as [number, number],
-          [0, -60]
-        )
+  selectedFeature$: Observable<MapClickedFeature<GeojsonProperties>> = this.mapStateService.selectedMapFeature$.pipe(
+    tap((feature) =>
+      this.mapService.flyTo(
+        feature.geometry.coordinates as [number, number],
+        [0, -60]
       )
-    );
-  }
+    )
+  );
 }

--- a/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.html
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.html
@@ -40,6 +40,9 @@
             <ion-label (click)="onGoToArtist(act?.name)">
               {{ act?.name }}
             </ion-label>
+            @if (act.onAir) {
+              <span slot="end" class="on-air"></span>
+            }
           </ion-item>
         }
       </ion-list>

--- a/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.html
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.html
@@ -1,31 +1,5 @@
 <div class="container">
   <header>
-    <ion-toolbar mode="md">
-      <ion-title>{{ stageName$ | async }}</ion-title>
-
-      <ion-buttons slot="end">
-        @if (tickets$ | async) {
-          <ion-button id="open-tickets-modal">
-            <ion-icon slot="icon-only" name="ticket-outline"></ion-icon>
-          </ion-button>
-        }
-        @if (hasTimetable$ | async) {
-          <ion-button id="open-description-modal">
-            <ion-icon slot="icon-only" name="information-outline"></ion-icon>
-          </ion-button>
-        }
-        @if (location$ | async; as location) {
-          <ion-button
-            color="primary"
-            fill="outline"
-            (click)="onOpenGoogleMapsDirections(location)"
-          >
-            Directions
-          </ion-button>
-        }
-      </ion-buttons>
-    </ion-toolbar>
-
     @if (days$ | async; as days) {
       <ion-toolbar>
         <ion-segment
@@ -39,6 +13,12 @@
             </ion-segment-button>
           }
         </ion-segment>
+      </ion-toolbar>
+    } @else {
+      <ion-toolbar>
+        <ion-title>
+          {{ stageName$ | async }}
+        </ion-title>
       </ion-toolbar>
     }
   </header>
@@ -86,20 +66,38 @@
             </ion-badge>
           </div>
         }
-        @if (url$ | async; as url) {
-          <div class="more-info ion-text-center">
-            <ion-button color="primary" (click)="onGoToUrl(url)">
-              More info
-            </ion-button>
-          </div>
-        }
       </div>
     }
   </main>
+
+  <ion-footer>
+    @if (location$ | async; as location) {
+      <ion-button fill="outline" (click)="onOpenGoogleMapsDirections(location)">
+        <ion-icon slot="start" name="compass-outline"></ion-icon>
+        Directions
+      </ion-button>
+    }
+    @if ((hasTimetable$ | async) && (stageDescription$ | async)) {
+      <ion-button id="open-description-modal" fill="outline">
+        <ion-icon name="information-outline"></ion-icon>
+      </ion-button>
+    }
+    @if (url$ | async; as url) {
+      <ion-button fill="outline" (click)="onGoToUrl(url)">
+        More info
+      </ion-button>
+    }
+    @if (tickets$ | async) {
+      <ion-button fill="outline" id="open-tickets-modal">
+        <ion-icon slot="start" name="ticket-outline"></ion-icon>
+        Tickets
+      </ion-button>
+    }
+  </ion-footer>
 </div>
 
 <!-- Modals for tickets and description -->
-@if (hasTimetable$ | async) {
+@if ((hasTimetable$ | async) && (stageDescription$ | async)) {
   <ion-modal
     trigger="open-description-modal"
     [initialBreakpoint]="0.4"

--- a/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.scss
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.scss
@@ -17,6 +17,14 @@
       .time-slot {
         color: var(--ion-color-step-600);
       }
+
+      .on-air {
+        background-color: var(--ion-color-warning);
+        border-radius: 50%;
+        width: 12px;
+        height: 12px;
+        animation: pulsing 3s infinite;
+      }
     }
 
     .description {
@@ -58,6 +66,23 @@
   100% {
     opacity: 1;
     transform: none;
+  }
+}
+
+@keyframes pulsing {
+  0% {
+    transform: scale(0.5, 0.5);
+    opacity: 0.5;
+  }
+
+  50% {
+    opacity: 1.0;
+    transform: scale(1, 1);
+  }
+
+  100% {
+    transform: scale(0.5, 0.5);
+    opacity: 0.5;
   }
 }
 

--- a/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.scss
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.scss
@@ -36,6 +36,13 @@
       }
     }
   }
+
+  ion-footer {
+    display: flex;
+    justify-content: space-between;
+    padding: 10px;
+    flex-direction: row-reverse;
+  }
 }
 
 .stage-description {
@@ -66,6 +73,6 @@
 
 /* Handle */
 ::-webkit-scrollbar-thumb {
-  background: var(--ion-color-primary);
+  background: var(--ion-color-tertiary);
   border-radius: 5px;
 }

--- a/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.scss
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.scss
@@ -40,7 +40,7 @@
   ion-footer {
     display: flex;
     justify-content: space-between;
-    padding: 10px;
+    padding: 10px 10px 15px 10px;
     flex-direction: row-reverse;
   }
 }

--- a/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.ts
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.ts
@@ -7,7 +7,7 @@ import {
 import { Router } from '@angular/router';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
-import { ModalController, SegmentCustomEvent } from '@ionic/angular/standalone';
+import { ModalController, SegmentCustomEvent, IonFooter } from '@ionic/angular/standalone';
 import { Browser } from '@capacitor/browser';
 import { MapStateService } from '@distortion/app/pages/map/state/map-state.service';
 import { MapLayer } from '@distortion/app/interfaces/map-layer';
@@ -44,6 +44,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    IonFooter,
     NgIf,
     NgFor,
     AsyncPipe,

--- a/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.ts
+++ b/apps/distortion/src/app/pages/map/feature-info-modal/stage-timetable/stage-timetable.component.ts
@@ -36,6 +36,11 @@ import {
   IonContent,
   IonList,
 } from '@ionic/angular/standalone';
+import { isSameDay, sub } from 'date-fns';
+
+interface TimetableViewModel extends Timetable {
+  onAir: boolean;
+}
 
 @Component({
   selector: 'app-stage-timetable',
@@ -74,7 +79,7 @@ export class StageTimetableComponent implements OnInit {
   stageDescription$: Observable<string>;
   tickets$: Observable<Ticket[]>;
   days$: Observable<Day[]>;
-  timetable$: Observable<Timetable[]>;
+  timetable$: Observable<TimetableViewModel[]>;
   hasTimetable$: Observable<boolean>;
   location$: Observable<[number, number]>;
   tags$: Observable<string[]>;
@@ -108,7 +113,17 @@ export class StageTimetableComponent implements OnInit {
             (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
           ),
       ),
-      tap((days) => this._selectedDay$.next(days[0].id)),
+      tap((days) => {
+        // Change day at 7am next day (for events running during nighttime)
+        const now = sub(new Date(), { hours: 7 });
+        const day = days.find((day) => isSameDay(now, new Date(day.date)));
+
+        if (day) {
+          this._selectedDay$.next(day.id);
+        } else {
+          this._selectedDay$.next(days[0].id);
+        }
+      }),
     );
 
     this.timetable$ = combineLatest([stage$, this.selectedDay$]).pipe(
@@ -119,6 +134,12 @@ export class StageTimetableComponent implements OnInit {
             (timetable) => timetable.day.id === day,
           ).timetable,
       ),
+      map((timetable) => (
+        timetable.map(slot => ({
+          ...slot,
+          onAir: new Date() > new Date(slot.start_time) && new Date() < new Date(slot.end_time),
+        }))
+      ))
     );
 
     // If no timetables assigned to stage, backend returns [null] for timetables array

--- a/apps/distortion/src/app/pages/map/map.page.ts
+++ b/apps/distortion/src/app/pages/map/map.page.ts
@@ -98,6 +98,7 @@ export class MapPage implements OnInit, AfterViewInit, OnDestroy {
           );
           this.mapService.removeFeatureHighlight(MapLayer.EventHighLight);
           this.mapService.highlightFeature(MapLayer.DayEventMask, mask.id);
+          this.mapStateService.updateMapInteraction(true);
 
           // Default select event type if only one
           eventTypes.length === 1
@@ -135,6 +136,7 @@ export class MapPage implements OnInit, AfterViewInit, OnDestroy {
             [0, 30],
           );
           this.mapService.highlightFeature(MapLayer.EventHighLight, mask.id);
+          this.mapStateService.updateMapInteraction(true);
 
           // Select event if only one
           events.length === 0
@@ -159,6 +161,7 @@ export class MapPage implements OnInit, AfterViewInit, OnDestroy {
             [0, 30],
           );
           this.mapService.highlightFeature(MapLayer.EventHighLight, event.id);
+          this.mapStateService.updateMapInteraction(true);
         }),
         takeUntil(this.abandon$),
         catchError((err) => {

--- a/apps/distortion/src/app/pages/map/map.page.ts
+++ b/apps/distortion/src/app/pages/map/map.page.ts
@@ -96,6 +96,8 @@ export class MapPage implements OnInit, AfterViewInit, OnDestroy {
             80,
             [0, 30],
           );
+          this.mapService.removeFeatureHighlight(MapLayer.StageHighlight);
+          this.mapService.removeFeatureHighlight(MapLayer.AssetHighlight);
           this.mapService.removeFeatureHighlight(MapLayer.EventHighLight);
           this.mapService.highlightFeature(MapLayer.DayEventMask, mask.id);
           this.mapStateService.updateMapInteraction(true);
@@ -135,6 +137,8 @@ export class MapPage implements OnInit, AfterViewInit, OnDestroy {
             80,
             [0, 30],
           );
+          this.mapService.removeFeatureHighlight(MapLayer.StageHighlight);
+          this.mapService.removeFeatureHighlight(MapLayer.AssetHighlight);
           this.mapService.highlightFeature(MapLayer.EventHighLight, mask.id);
           this.mapStateService.updateMapInteraction(true);
 
@@ -160,6 +164,8 @@ export class MapPage implements OnInit, AfterViewInit, OnDestroy {
             10,
             [0, 30],
           );
+          this.mapService.removeFeatureHighlight(MapLayer.AssetHighlight);
+          this.mapService.removeFeatureHighlight(MapLayer.StageHighlight);
           this.mapService.highlightFeature(MapLayer.EventHighLight, event.id);
           this.mapStateService.updateMapInteraction(true);
         }),

--- a/apps/distortion/src/app/shared/icons.ts
+++ b/apps/distortion/src/app/shared/icons.ts
@@ -29,7 +29,8 @@ import {
   thumbsUpOutline,
   ticket,
   ticketOutline,
-  shareSocialOutline
+  shareSocialOutline,
+  compassOutline,
 } from 'ionicons/icons';
 
 export const icons = {
@@ -64,4 +65,5 @@ export const icons = {
   ticket,
   ticketOutline,
   shareSocialOutline,
+  compassOutline,
 };


### PR DESCRIPTION
- Hide map feature info modal when using day-event-filter
- Moved action buttons to footer in map stage info modal
- Update asset component HTML to include primary color outline button for directions
- Add on-air pulsing dot on stage timetable and default select current day
